### PR TITLE
Allow specifying Max Gas Fee during transfer initiation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2929,7 +2929,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "satoshi-bridge"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bitcoin",
  "crypto-shared",

--- a/contracts/satoshi-bridge/Cargo.toml
+++ b/contracts/satoshi-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "satoshi-bridge"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 publish.workspace = true
 repository.workspace = true

--- a/contracts/satoshi-bridge/src/api/token_receiver.rs
+++ b/contracts/satoshi-bridge/src/api/token_receiver.rs
@@ -9,6 +9,7 @@ pub enum TokenReceiverMessage {
         target_btc_address: String,
         input: Vec<OutPoint>,
         output: Vec<TxOut>,
+        max_gas_fee: Option<U128>,
     },
 }
 
@@ -47,6 +48,7 @@ impl FungibleTokenReceiver for Contract {
                 target_btc_address,
                 input,
                 output,
+                max_gas_fee,
             } => {
                 let (psbt, utxo_storage_keys, vutxos) =
                     self.generate_psbt_and_vutxos(input, output);
@@ -69,6 +71,7 @@ impl FungibleTokenReceiver for Contract {
                     &vutxos,
                     amount,
                     withdraw_fee,
+                    max_gas_fee
                 );
 
                 let need_signature_num = psbt.unsigned_tx.input.len();

--- a/contracts/satoshi-bridge/src/psbt.rs
+++ b/contracts/satoshi-bridge/src/psbt.rs
@@ -9,6 +9,7 @@ impl Contract {
         vutxos: &[VUTXO],
         amount: u128,
         withdraw_fee: u128,
+        max_gas_fee: Option<U128>,
     ) -> (u128, u128) {
         let config = self.internal_config();
         let utxo_num = self.data().utxos.len() + vutxos.len() as u32;
@@ -20,6 +21,10 @@ impl Contract {
             amount,
             withdraw_fee,
         );
+        
+        if let Some(max_gas_fee) = max_gas_fee {
+            require!(gas_fee <= max_gas_fee.0, format!("Gas fee does not match the provided max fee (gas fee = {}; max gas fee = {})", gas_fee, max_gas_fee.0));
+        }
 
         require!(
             change_num <= config.max_change_number as usize,


### PR DESCRIPTION
This pull request introduces support for specifying a maximum gas fee when processing token receiver messages in the Satoshi Bridge contract. The changes ensure that transactions will not proceed if the calculated gas fee exceeds the provided maximum, adding an extra layer of user protection.

**Support for maximum gas fee in token receiver flow:**

* Added an optional `max_gas_fee` field of type `Option<U128>` to the `TokenReceiverMessage::WithdrawToBTCAddress` variant to allow users to specify a maximum acceptable gas fee.
* Updated the `FungibleTokenReceiver` implementation to propagate the new `max_gas_fee` parameter through the withdrawal processing flow.
* Modified the call to `calculate_fee_and_change` to accept the `max_gas_fee` parameter.
* Updated the signature of `calculate_fee_and_change` in `psbt.rs` to include the optional `max_gas_fee` argument.

**Gas fee validation logic:**

* Added a check inside `calculate_fee_and_change` to ensure that the computed gas fee does not exceed the provided `max_gas_fee`, raising an error if the limit is breached.