### PR TITLE
fix: `utxo_id` injection in nested json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3715,7 +3715,7 @@ dependencies = [
 
 [[package]]
 name = "satoshi-bridge"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bitcoin",
  "core2",

--- a/contracts/satoshi-bridge/Cargo.toml
+++ b/contracts/satoshi-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "satoshi-bridge"
-version = "0.7.1"
+version = "0.7.2"
 edition.workspace = true
 publish.workspace = true
 repository.workspace = true

--- a/contracts/satoshi-bridge/src/btc_light_client/deposit.rs
+++ b/contracts/satoshi-bridge/src/btc_light_client/deposit.rs
@@ -328,7 +328,7 @@ mod tests {
 
     #[near(serializers=[json])]
     #[derive(Debug, Clone, PartialEq, Eq)]
-    pub struct UtxoFinTransferInner {
+    pub struct UtxoFinTransferMsg {
         pub utxo_id: String,
         pub recipient: String,
         pub relayer_fee: String,
@@ -337,9 +337,8 @@ mod tests {
 
     #[near(serializers=[json])]
     #[derive(Debug, Clone, PartialEq, Eq)]
-    pub struct UtxoFinTransferMsg {
-        #[serde(rename = "UtxoFinTransfer")]
-        pub inner: UtxoFinTransferInner,
+    pub enum BridgeOnTransferMsg {
+        UtxoFinTransfer(UtxoFinTransferMsg),
     }
 
     #[test]
@@ -349,8 +348,8 @@ mod tests {
                 .to_string();
 
         let injected_msg = inject_utxo_id_in_msg(duplicated_msg, "correct_utxo_id");
-        let parsed_msg: UtxoFinTransferInner = serde_json::from_str(&injected_msg).unwrap();
-        let expected = UtxoFinTransferInner {
+        let parsed_msg: UtxoFinTransferMsg = serde_json::from_str(&injected_msg).unwrap();
+        let expected = UtxoFinTransferMsg {
             utxo_id: "correct_utxo_id".to_string(),
             recipient: "some_recipient".to_string(),
             relayer_fee: "1000".to_string(),
@@ -367,15 +366,13 @@ mod tests {
                 .to_string();
 
         let injected_msg = inject_utxo_id_in_msg(nested_msg, "correct_utxo_id");
-        let parsed_msg: UtxoFinTransferMsg = serde_json::from_str(&injected_msg).unwrap();
-        let expected = UtxoFinTransferMsg {
-            inner: UtxoFinTransferInner {
-                utxo_id: "correct_utxo_id".to_string(),
-                recipient: "some_recipient".to_string(),
-                relayer_fee: "1000".to_string(),
-                msg: "OS".to_string(),
-            },
-        };
+        let parsed_msg: BridgeOnTransferMsg = serde_json::from_str(&injected_msg).unwrap();
+        let expected = BridgeOnTransferMsg::UtxoFinTransfer(UtxoFinTransferMsg {
+            utxo_id: "correct_utxo_id".to_string(),
+            recipient: "some_recipient".to_string(),
+            relayer_fee: "1000".to_string(),
+            msg: "OS".to_string(),
+        });
 
         assert_eq!(parsed_msg, expected);
     }
@@ -387,15 +384,13 @@ mod tests {
                 .to_string();
 
         let injected_msg = inject_utxo_id_in_msg(nested_msg, "correct_utxo_id");
-        let parsed_msg: UtxoFinTransferMsg = serde_json::from_str(&injected_msg).unwrap();
-        let expected = UtxoFinTransferMsg {
-            inner: UtxoFinTransferInner {
-                utxo_id: "correct_utxo_id".to_string(),
-                recipient: "some_recipient".to_string(),
-                relayer_fee: "1000".to_string(),
-                msg: "OS".to_string(),
-            },
-        };
+        let parsed_msg: BridgeOnTransferMsg = serde_json::from_str(&injected_msg).unwrap();
+        let expected = BridgeOnTransferMsg::UtxoFinTransfer(UtxoFinTransferMsg {
+            utxo_id: "correct_utxo_id".to_string(),
+            recipient: "some_recipient".to_string(),
+            relayer_fee: "1000".to_string(),
+            msg: "OS".to_string(),
+        });
 
         assert_eq!(parsed_msg, expected);
     }

--- a/contracts/satoshi-bridge/src/btc_light_client/deposit.rs
+++ b/contracts/satoshi-bridge/src/btc_light_client/deposit.rs
@@ -275,40 +275,90 @@ fn is_refund_required() -> bool {
 }
 
 fn inject_utxo_id_in_msg(msg: String, utxo_id: &str) -> String {
-    if let Ok(mut json) = serde_json::from_str::<Value>(&msg) {
-        if let Some(field) = json.get_mut("utxo_id") {
-            *field = Value::String(utxo_id.to_string());
-            return serde_json::to_string(&json).unwrap();
+    fn inject(value: &mut Value, utxo_id: &str) {
+        match value {
+            Value::Object(map) => {
+                for (k, v) in map.iter_mut() {
+                    if k == "utxo_id" {
+                        *v = Value::String(utxo_id.to_string());
+                    } else {
+                        inject(v, utxo_id);
+                    }
+                }
+            }
+            Value::Array(arr) => {
+                for v in arr.iter_mut() {
+                    inject(v, utxo_id);
+                }
+            }
+            _ => {}
         }
     }
-    msg
+
+    if let Ok(mut json) = serde_json::from_str::<Value>(&msg) {
+        inject(&mut json, utxo_id);
+        serde_json::to_string(&json).unwrap_or(msg)
+    } else {
+        msg
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::btc_light_client::deposit::inject_utxo_id_in_msg;
-    use near_sdk::{json_types::U128, near, serde_json};
+    use near_sdk::{near, serde_json};
 
-    #[near(serializers=[json])]
-    #[derive(Debug, Clone)]
-    pub struct UtxoFinTransferMsg {
+    #[near(serializers = [json])]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct UtxoFinTransferInner {
         pub utxo_id: String,
-        pub x: String,
-        pub y: U128,
-        pub z: String,
+        pub recipient: String,
+        pub relayer_fee: String,
+        pub msg: String,
+    }
+
+    #[near(serializers = [json])]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct UtxoFinTransferMsg {
+        #[serde(rename = "UtxoFinTransfer")]
+        pub inner: UtxoFinTransferInner,
+    }
+
+    #[test]
+    fn test_duplicated_utxo_id_injection() {
+        let duplicated_msg =
+            r#"{"utxo_id":"first","utxo_id":"second","recipient":"some_recipient","relayer_fee":"1000","msg":"OS"}"#
+                .to_string();
+
+        let injected_msg = inject_utxo_id_in_msg(duplicated_msg, "correct_utxo_id");
+        let parsed_msg: UtxoFinTransferInner = serde_json::from_str(&injected_msg).unwrap();
+        let expected = UtxoFinTransferInner {
+            utxo_id: "correct_utxo_id".to_string(),
+            recipient: "some_recipient".to_string(),
+            relayer_fee: "1000".to_string(),
+            msg: "OS".to_string(),
+        };
+        assert_eq!(parsed_msg, expected);
     }
 
     #[test]
     fn test_utxo_id_injection() {
-        let duplicated_msg =
-            r#"{"utxo_id":"first","utxo_id":"second","x":"some_recipient","y":"1000","z":"OS"}"#
+        let nested_msg =
+            r#"{"UtxoFinTransfer":{"msg":"","recipient":"sol:BXss9YNCX2p6VPf2Em54pHXkXnC2FPBeZgbB9fY1cuBR","relayer_fee":"12","utxo_id":"{{UTXO_TX_ID}}"}}"#
                 .to_string();
 
-        let injected_msg = inject_utxo_id_in_msg(duplicated_msg, "correct_utxo_id");
+        let injected_msg = inject_utxo_id_in_msg(nested_msg, "correct_utxo_id");
+        println!("Injected msg: {}", injected_msg);
         let parsed_msg: UtxoFinTransferMsg = serde_json::from_str(&injected_msg).unwrap();
-        assert_eq!(parsed_msg.utxo_id, "correct_utxo_id");
+        let expected = UtxoFinTransferMsg {
+            inner: UtxoFinTransferInner {
+                utxo_id: "correct_utxo_id".to_string(),
+                recipient: "sol:BXss9YNCX2p6VPf2Em54pHXkXnC2FPBeZgbB9fY1cuBR".to_string(),
+                relayer_fee: "12".to_string(),
+                msg: "".to_string(),
+            },
+        };
 
-        let expected = r#"{"utxo_id":"correct_utxo_id","x":"some_recipient","y":"1000","z":"OS"}"#;
-        assert_eq!(injected_msg, expected);
+        assert_eq!(parsed_msg, expected);
     }
 }

--- a/contracts/satoshi-bridge/src/btc_light_client/deposit.rs
+++ b/contracts/satoshi-bridge/src/btc_light_client/deposit.rs
@@ -308,7 +308,7 @@ mod tests {
     use crate::btc_light_client::deposit::inject_utxo_id_in_msg;
     use near_sdk::{near, serde_json};
 
-    #[near(serializers = [json])]
+    #[near(serializers=[json])]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct UtxoFinTransferInner {
         pub utxo_id: String,
@@ -317,7 +317,7 @@ mod tests {
         pub msg: String,
     }
 
-    #[near(serializers = [json])]
+    #[near(serializers=[json])]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct UtxoFinTransferMsg {
         #[serde(rename = "UtxoFinTransfer")]

--- a/contracts/satoshi-bridge/src/btc_light_client/deposit.rs
+++ b/contracts/satoshi-bridge/src/btc_light_client/deposit.rs
@@ -291,34 +291,16 @@ fn inject_utxo_id_in_msg(msg: String, utxo_id: &str) -> String {
                     inject(v, utxo_id);
                 }
             }
-            Value::String(s) => {
-                if let Ok(mut inner) = serde_json::from_str::<Value>(s) {
-                    inject(&mut inner, utxo_id);
-                    if let Ok(new_s) = serde_json::to_string(&inner) {
-                        *s = new_s;
-                    }
-                }
-            }
             _ => {}
         }
     }
 
     if let Ok(mut json) = serde_json::from_str::<Value>(&msg) {
         inject(&mut json, utxo_id);
-        return serde_json::to_string(&json).unwrap_or(msg);
+        serde_json::to_string(&json).unwrap()
+    } else {
+        msg
     }
-
-    let wrapped = format!("\"{msg}\"");
-    if let Ok(unescaped) = serde_json::from_str::<String>(&wrapped) {
-        if let Ok(mut json) = serde_json::from_str::<Value>(&unescaped) {
-            inject(&mut json, utxo_id);
-            return serde_json::to_string(&json).unwrap_or(unescaped);
-        }
-
-        return unescaped;
-    }
-
-    msg
 }
 
 #[cfg(test)]
@@ -363,24 +345,6 @@ mod tests {
     fn test_utxo_id_injection() {
         let nested_msg =
             r#"{"UtxoFinTransfer":{"msg":"OS","recipient":"some_recipient","relayer_fee":"1000","utxo_id":"{{UTXO_TX_ID}}"}}"#
-                .to_string();
-
-        let injected_msg = inject_utxo_id_in_msg(nested_msg, "correct_utxo_id");
-        let parsed_msg: BridgeOnTransferMsg = serde_json::from_str(&injected_msg).unwrap();
-        let expected = BridgeOnTransferMsg::UtxoFinTransfer(UtxoFinTransferMsg {
-            utxo_id: "correct_utxo_id".to_string(),
-            recipient: "some_recipient".to_string(),
-            relayer_fee: "1000".to_string(),
-            msg: "OS".to_string(),
-        });
-
-        assert_eq!(parsed_msg, expected);
-    }
-
-    #[test]
-    fn test_escaped_utxo_id_injection() {
-        let nested_msg =
-            r#"{\"UtxoFinTransfer\":{\"msg\":\"OS\",\"recipient\":\"some_recipient\",\"relayer_fee\":\"1000\",\"utxo_id\":\"{{UTXO_TX_ID}}\"}}"#
                 .to_string();
 
         let injected_msg = inject_utxo_id_in_msg(nested_msg, "correct_utxo_id");

--- a/contracts/satoshi-bridge/src/btc_light_client/deposit.rs
+++ b/contracts/satoshi-bridge/src/btc_light_client/deposit.rs
@@ -291,16 +291,34 @@ fn inject_utxo_id_in_msg(msg: String, utxo_id: &str) -> String {
                     inject(v, utxo_id);
                 }
             }
+            Value::String(s) => {
+                if let Ok(mut inner) = serde_json::from_str::<Value>(s) {
+                    inject(&mut inner, utxo_id);
+                    if let Ok(new_s) = serde_json::to_string(&inner) {
+                        *s = new_s;
+                    }
+                }
+            }
             _ => {}
         }
     }
 
     if let Ok(mut json) = serde_json::from_str::<Value>(&msg) {
         inject(&mut json, utxo_id);
-        serde_json::to_string(&json).unwrap_or(msg)
-    } else {
-        msg
+        return serde_json::to_string(&json).unwrap_or(msg);
     }
+
+    let wrapped = format!("\"{}\"", msg);
+    if let Ok(unescaped) = serde_json::from_str::<String>(&wrapped) {
+        if let Ok(mut json) = serde_json::from_str::<Value>(&unescaped) {
+            inject(&mut json, utxo_id);
+            return serde_json::to_string(&json).unwrap_or(unescaped);
+        } else {
+            return unescaped;
+        }
+    }
+
+    msg
 }
 
 #[cfg(test)]
@@ -338,6 +356,7 @@ mod tests {
             relayer_fee: "1000".to_string(),
             msg: "OS".to_string(),
         };
+
         assert_eq!(parsed_msg, expected);
     }
 
@@ -348,7 +367,26 @@ mod tests {
                 .to_string();
 
         let injected_msg = inject_utxo_id_in_msg(nested_msg, "correct_utxo_id");
-        println!("Injected msg: {}", injected_msg);
+        let parsed_msg: UtxoFinTransferMsg = serde_json::from_str(&injected_msg).unwrap();
+        let expected = UtxoFinTransferMsg {
+            inner: UtxoFinTransferInner {
+                utxo_id: "correct_utxo_id".to_string(),
+                recipient: "some_recipient".to_string(),
+                relayer_fee: "1000".to_string(),
+                msg: "OS".to_string(),
+            },
+        };
+
+        assert_eq!(parsed_msg, expected);
+    }
+
+    #[test]
+    fn test_escaped_utxo_id_injection() {
+        let nested_msg =
+            r#"{\"UtxoFinTransfer\":{\"msg\":\"OS\",\"recipient\":\"some_recipient\",\"relayer_fee\":\"1000\",\"utxo_id\":\"{{UTXO_TX_ID}}\"}}"#
+                .to_string();
+
+        let injected_msg = inject_utxo_id_in_msg(nested_msg, "correct_utxo_id");
         let parsed_msg: UtxoFinTransferMsg = serde_json::from_str(&injected_msg).unwrap();
         let expected = UtxoFinTransferMsg {
             inner: UtxoFinTransferInner {

--- a/contracts/satoshi-bridge/src/btc_light_client/deposit.rs
+++ b/contracts/satoshi-bridge/src/btc_light_client/deposit.rs
@@ -358,4 +358,22 @@ mod tests {
 
         assert_eq!(parsed_msg, expected);
     }
+
+    #[test]
+    fn test_already_set_utxo_id_injection() {
+        let nested_msg =
+            r#"{"UtxoFinTransfer":{"msg":"OS","recipient":"{{UTXO_TX_ID}}","relayer_fee":"1000","utxo_id":"invalid_utxo_id"}}"#
+                .to_string();
+
+        let injected_msg = inject_utxo_id_in_msg(nested_msg, "correct_utxo_id");
+        let parsed_msg: BridgeOnTransferMsg = serde_json::from_str(&injected_msg).unwrap();
+        let expected = BridgeOnTransferMsg::UtxoFinTransfer(UtxoFinTransferMsg {
+            utxo_id: "correct_utxo_id".to_string(),
+            recipient: "{{UTXO_TX_ID}}".to_string(),
+            relayer_fee: "1000".to_string(),
+            msg: "OS".to_string(),
+        });
+
+        assert_eq!(parsed_msg, expected);
+    }
 }

--- a/contracts/satoshi-bridge/src/btc_light_client/deposit.rs
+++ b/contracts/satoshi-bridge/src/btc_light_client/deposit.rs
@@ -308,14 +308,14 @@ fn inject_utxo_id_in_msg(msg: String, utxo_id: &str) -> String {
         return serde_json::to_string(&json).unwrap_or(msg);
     }
 
-    let wrapped = format!("\"{}\"", msg);
+    let wrapped = format!("\"{msg}\"");
     if let Ok(unescaped) = serde_json::from_str::<String>(&wrapped) {
         if let Ok(mut json) = serde_json::from_str::<Value>(&unescaped) {
             inject(&mut json, utxo_id);
             return serde_json::to_string(&json).unwrap_or(unescaped);
-        } else {
-            return unescaped;
         }
+
+        return unescaped;
     }
 
     msg

--- a/contracts/satoshi-bridge/src/btc_light_client/deposit.rs
+++ b/contracts/satoshi-bridge/src/btc_light_client/deposit.rs
@@ -344,7 +344,7 @@ mod tests {
     #[test]
     fn test_utxo_id_injection() {
         let nested_msg =
-            r#"{"UtxoFinTransfer":{"msg":"","recipient":"sol:BXss9YNCX2p6VPf2Em54pHXkXnC2FPBeZgbB9fY1cuBR","relayer_fee":"12","utxo_id":"{{UTXO_TX_ID}}"}}"#
+            r#"{"UtxoFinTransfer":{"msg":"OS","recipient":"some_recipient","relayer_fee":"1000","utxo_id":"{{UTXO_TX_ID}}"}}"#
                 .to_string();
 
         let injected_msg = inject_utxo_id_in_msg(nested_msg, "correct_utxo_id");
@@ -353,9 +353,9 @@ mod tests {
         let expected = UtxoFinTransferMsg {
             inner: UtxoFinTransferInner {
                 utxo_id: "correct_utxo_id".to_string(),
-                recipient: "sol:BXss9YNCX2p6VPf2Em54pHXkXnC2FPBeZgbB9fY1cuBR".to_string(),
-                relayer_fee: "12".to_string(),
-                msg: "".to_string(),
+                recipient: "some_recipient".to_string(),
+                relayer_fee: "1000".to_string(),
+                msg: "OS".to_string(),
             },
         };
 


### PR DESCRIPTION
This pull request updates the `inject_utxo_id_in_msg` function to handle nested and duplicated `utxo_id` fields within JSON messages, ensuring all instances are correctly set. It also expands and improves the test coverage for these scenarios, and bumps the crate version to reflect these enhancements.

**Enhancements to `inject_utxo_id_in_msg` logic:**

* Refactored the function to recursively traverse JSON objects and arrays, updating all occurrences of the `utxo_id` field, including nested and duplicated keys.

**Improvements to test coverage and types:**

* Added and updated tests to cover scenarios with duplicated, nested, and pre-set `utxo_id` fields, ensuring correct injection in all cases.
* Introduced new types (`UtxoFinTransferMsg`, `BridgeOnTransferMsg`) and derived `PartialEq`, `Eq` for more robust and precise test assertions.

**Version update:**

* Bumped the crate version in `Cargo.toml` from `0.7.1` to `0.7.2` to reflect the new functionality and fixes.