### PR TITLE
Log balances for UtxoAdded Events

### DIFF
--- a/contracts/satoshi-bridge/src/btc_light_client/deposit.rs
+++ b/contracts/satoshi-bridge/src/btc_light_client/deposit.rs
@@ -223,6 +223,9 @@ impl Contract {
         if is_success {
             Event::UtxoAdded {
                 utxo_storage_keys: vec![pending_utxo_info.utxo_storage_key.clone()],
+                balances: Some(vec![U128::from(<u64 as Into<u128>>::into(
+                    pending_utxo_info.utxo.balance,
+                ))]),
             }
             .emit();
             self.internal_set_utxo(&pending_utxo_info.utxo_storage_key, pending_utxo_info.utxo);

--- a/contracts/satoshi-bridge/src/btc_light_client/deposit.rs
+++ b/contracts/satoshi-bridge/src/btc_light_client/deposit.rs
@@ -223,9 +223,7 @@ impl Contract {
         if is_success {
             Event::UtxoAdded {
                 utxo_storage_keys: vec![pending_utxo_info.utxo_storage_key.clone()],
-                balances: Some(vec![U128::from(<u64 as Into<u128>>::into(
-                    pending_utxo_info.utxo.balance,
-                ))]),
+                balances: Some(vec![U128(pending_utxo_info.utxo.balance.into())]),
             }
             .emit();
             self.internal_set_utxo(&pending_utxo_info.utxo_storage_key, pending_utxo_info.utxo);

--- a/contracts/satoshi-bridge/src/event.rs
+++ b/contracts/satoshi-bridge/src/event.rs
@@ -84,6 +84,7 @@ pub enum Event<'a> {
     },
     UtxoAdded {
         utxo_storage_keys: Vec<String>,
+        balances: Option<Vec<U128>>,
     },
     UtxoRemoved {
         utxo_storage_keys: Vec<String>,

--- a/contracts/satoshi-bridge/src/nbtc/burn.rs
+++ b/contracts/satoshi-bridge/src/nbtc/burn.rs
@@ -81,6 +81,7 @@ impl Contract {
                 .expect("Deserialization tx_bytes failed");
             let withdraw_change_script_pubkey = config.get_change_script_pubkey();
             let mut utxo_storage_keys = vec![];
+            let mut balances = vec![];
             for (index, output) in transaction.output().into_iter().enumerate() {
                 if withdraw_change_script_pubkey == output.script_pubkey {
                     let utxo = UTXO {
@@ -93,6 +94,7 @@ impl Contract {
                         tx_id.clone(),
                         u32::try_from(index).unwrap_or_else(|_| env::panic_str("Index overflow")),
                     );
+                    balances.push(U128::from(<u64 as Into<u128>>::into(utxo.balance)));
                     self.internal_set_utxo(&utxo_storage_key, utxo);
                     utxo_storage_keys.push(utxo_storage_key);
                 }
@@ -138,7 +140,11 @@ impl Contract {
                 self.internal_transfer_nbtc(&btc_pending_info.account_id, refund);
             }
             self.internal_remove_btc_pending_info(&tx_id);
-            Event::UtxoAdded { utxo_storage_keys }.emit();
+            Event::UtxoAdded {
+                utxo_storage_keys,
+                balances: Some(balances),
+            }
+            .emit();
         } else {
             self.internal_unwrap_mut_btc_pending_info(&tx_id)
                 .to_pending_verify_stage();
@@ -163,6 +169,7 @@ impl Contract {
             let config = self.internal_config();
             let withdraw_change_script_pubkey = config.get_change_script_pubkey();
             let mut utxo_storage_keys = vec![];
+            let mut balances: Vec<U128> = vec![];
             for (index, output) in transaction.output().into_iter().enumerate() {
                 if withdraw_change_script_pubkey == output.script_pubkey {
                     let utxo = UTXO {
@@ -175,6 +182,8 @@ impl Contract {
                         tx_id.clone(),
                         u32::try_from(index).unwrap_or_else(|_| env::panic_str("Index overflow")),
                     );
+
+                    balances.push(U128::from(<u64 as Into<u128>>::into(utxo.balance)));
                     self.internal_set_utxo(&utxo_storage_key, utxo);
                     utxo_storage_keys.push(utxo_storage_key);
                 }
@@ -205,7 +214,11 @@ impl Contract {
                 self.data_mut().rbf_txs.remove(&tx_id);
             }
             self.internal_remove_btc_pending_info(&tx_id);
-            Event::UtxoAdded { utxo_storage_keys }.emit();
+            Event::UtxoAdded {
+                utxo_storage_keys,
+                balances: Some(balances),
+            }
+            .emit();
         } else {
             self.internal_unwrap_mut_btc_pending_info(&tx_id)
                 .to_pending_verify_stage();

--- a/contracts/satoshi-bridge/src/nbtc/burn.rs
+++ b/contracts/satoshi-bridge/src/nbtc/burn.rs
@@ -94,7 +94,7 @@ impl Contract {
                         tx_id.clone(),
                         u32::try_from(index).unwrap_or_else(|_| env::panic_str("Index overflow")),
                     );
-                    balances.push(U128::from(<u64 as Into<u128>>::into(utxo.balance)));
+                    balances.push(U128::from(u128::from(utxo.balance)));
                     self.internal_set_utxo(&utxo_storage_key, utxo);
                     utxo_storage_keys.push(utxo_storage_key);
                 }

--- a/contracts/satoshi-bridge/src/nbtc/burn.rs
+++ b/contracts/satoshi-bridge/src/nbtc/burn.rs
@@ -183,7 +183,7 @@ impl Contract {
                         u32::try_from(index).unwrap_or_else(|_| env::panic_str("Index overflow")),
                     );
 
-                    balances.push(U128::from(<u64 as Into<u128>>::into(utxo.balance)));
+                    balances.push(U128::from(u128::from(utxo.balance)));
                     self.internal_set_utxo(&utxo_storage_key, utxo);
                     utxo_storage_keys.push(utxo_storage_key);
                 }

--- a/contracts/satoshi-bridge/src/nbtc/mint.rs
+++ b/contracts/satoshi-bridge/src/nbtc/mint.rs
@@ -62,9 +62,7 @@ impl Contract {
             }
             Event::UtxoAdded {
                 utxo_storage_keys: vec![pending_utxo_info.utxo_storage_key.clone()],
-                balances: Some(vec![U128::from(<u64 as Into<u128>>::into(
-                    pending_utxo_info.utxo.balance,
-                ))]),
+                balances: Some(vec![U128::from(u128::from(pending_utxo_info.utxo.balance))]),
             }
             .emit();
             self.internal_set_utxo(&pending_utxo_info.utxo_storage_key, pending_utxo_info.utxo);

--- a/contracts/satoshi-bridge/src/nbtc/mint.rs
+++ b/contracts/satoshi-bridge/src/nbtc/mint.rs
@@ -62,6 +62,9 @@ impl Contract {
             }
             Event::UtxoAdded {
                 utxo_storage_keys: vec![pending_utxo_info.utxo_storage_key.clone()],
+                balances: Some(vec![U128::from(<u64 as Into<u128>>::into(
+                    pending_utxo_info.utxo.balance,
+                ))]),
             }
             .emit();
             self.internal_set_utxo(&pending_utxo_info.utxo_storage_key, pending_utxo_info.utxo);


### PR DESCRIPTION
Adds `balances` field to all `UtxoAdded` event emissions (deposit, mint, burn change-output).

Needed for tracking UTXOs and transfer fee calculation in  [bridge-indexer-rs](https://github.com/Near-One/bridge-indexer-rs/pull/295) 
