### PR TITLE
fix: remove lock time verification

### DIFF
--- a/contracts/satoshi-bridge/src/api/bridge.rs
+++ b/contracts/satoshi-bridge/src/api/bridge.rs
@@ -37,10 +37,6 @@ impl Contract {
             .expect("Deserialization tx_bytes failed");
         let deposit_amount = u128::from(transaction.output()[vout].value.to_sat());
         require!(deposit_amount > 0, "Invalid deposit_amount");
-        require!(
-            transaction.lock_time() == LockTime::ZERO,
-            "Tx with a non-zero lock_time are not supported."
-        );
         let deposit_address = self.generate_utxo_chain_address(&path);
         let deposit_address_script_pubkey = deposit_address
             .script_pubkey()


### PR DESCRIPTION
This pull request makes a targeted change to the deposit validation logic in the `Contract` implementation. Specifically, it removes the requirement that a transaction's `lock_time` must be zero. This means transactions with a non-zero `lock_time` are now supported, which could allow for more flexible transaction types in the bridge contract.

**Deposit validation update:**

* Removed the check that required `transaction.lock_time()` to be zero, allowing transactions with non-zero `lock_time` values to be processed.