### PR TITLE
fix: nbtc upgrade script

### DIFF
--- a/migrate/create_proposal.sh
+++ b/migrate/create_proposal.sh
@@ -1,4 +1,4 @@
-EXPECTED_NBTC_BS58_HASH=3dXNLxNT1cSso4SeDzffnpq1SynCBb95WF9gBLVYvYSE
+EXPECTED_NBTC_BS58_HASH=4ELM6EPYWg9NXHGkYHPqeGFBrGCs4vQMZf7pMFQAnP4H
 NBTC_ACCOUNT_ID=nbtc.bridge.near
 DAO_ACCOUNT_ID=rainbowbridge.sputnik-dao.near
 SIGNER_ACCOUNT_ID=bridge-ops.near
@@ -20,7 +20,7 @@ if [[ "$ACTUAL_NBTC_BS58_HASH" != "$EXPECTED_NBTC_BS58_HASH" ]]; then
   exit 1
 fi
 
-WASM_B64=$(base64 -w 0 $NBTC_WASM_PATH 2>/dev/null || base64 $NBTC_WASM_PATH | tr -d '\n')
+WASM_B64=$(base64 < $NBTC_WASM_PATH | tr -d '\n')
 
 {
   echo '{


### PR DESCRIPTION
Fix: make base64 encoding portable across Linux and macOS

The previous command base64 -w 0 $NBTC_WASM_PATH 2>/dev/null || base64 $NBTC_WASM_PATH | tr -d '\n' failed on macOS:

-w 0 is a GNU-only flag (unknown on BSD base64)
The fallback passed the wasm path as a positional argument, which BSD base64 rejects with invalid argument (it expects -i FILE or stdin)
Replaced with base64 < $NBTC_WASM_PATH | tr -d '\n', which uses stdin redirection — supported identically by both GNU and BSD base64 — and strips the default line wrapping to produce a single-line encoded string suitable for embedding in the proposal JSON.