### PR TITLE
Use Base64VecU8 for tx_bytes in callbacks and storage

### DIFF
--- a/contracts/satoshi-bridge/src/api/bridge.rs
+++ b/contracts/satoshi-bridge/src/api/bridge.rs
@@ -36,7 +36,7 @@ impl Contract {
     ) -> Promise {
         self.internal_verify_deposit_entry(
             deposit_msg,
-            tx_bytes,
+            Base64VecU8(tx_bytes),
             vout,
             tx_block_blockhash,
             tx_index,
@@ -70,7 +70,7 @@ impl Contract {
     ) -> Promise {
         self.internal_verify_deposit_entry(
             deposit_msg,
-            tx_bytes.0,
+            tx_bytes,
             vout,
             proof.tx_block_blockhash,
             proof.tx_index,
@@ -112,7 +112,7 @@ impl Contract {
     ) -> Promise {
         self.internal_safe_verify_deposit_entry(
             deposit_msg,
-            tx_bytes,
+            Base64VecU8(tx_bytes),
             vout,
             tx_block_blockhash,
             tx_index,
@@ -147,7 +147,7 @@ impl Contract {
     ) -> Promise {
         self.internal_safe_verify_deposit_entry(
             deposit_msg,
-            tx_bytes.0,
+            tx_bytes,
             vout,
             proof.tx_block_blockhash,
             proof.tx_index,

--- a/contracts/satoshi-bridge/src/api/view.rs
+++ b/contracts/satoshi-bridge/src/api/view.rs
@@ -1,8 +1,9 @@
 #[cfg(not(feature = "zcash"))]
 use crate::RefundRequest;
 use crate::{
-    env, near, u128_dec_format, AccessControllable, Account, AccountId, BTCPendingInfo, Config,
-    Contract, ContractExt, HashMap, HashSet, NearToken, Pausable, Role, U128, UTXO,
+    env, near, u128_dec_format, AccessControllable, Account, AccountId, BTCPendingInfo,
+    BTCPendingInfoView, Config, Contract, ContractExt, HashMap, HashSet, NearToken, Pausable, Role,
+    UTXOView, U128, UTXO,
 };
 
 const REQUIRED_BALANCE_FOR_DEPOSIT: NearToken =
@@ -149,6 +150,103 @@ impl Contract {
         &self,
         from_index: Option<usize>,
         limit: Option<usize>,
+    ) -> HashMap<String, UTXOView> {
+        let len = usize::try_from(self.data().utxos.len())
+            .unwrap_or_else(|_| env::panic_str("Too many utxos"));
+        let skip_n = from_index.unwrap_or(0);
+        let take_n = limit.unwrap_or(len - skip_n);
+        self.data()
+            .utxos
+            .iter()
+            .skip(skip_n)
+            .take(take_n)
+            .map(|(k, v)| (k.clone(), v.into()))
+            .collect()
+    }
+
+    pub fn list_utxos(&self, utxo_storage_keys: Vec<String>) -> HashMap<String, Option<UTXOView>> {
+        utxo_storage_keys
+            .into_iter()
+            .map(|key| (key.clone(), self.data().utxos.get(&key).map(Into::into)))
+            .collect()
+    }
+
+    pub fn get_unavailable_utxos_paged(
+        &self,
+        from_index: Option<usize>,
+        limit: Option<usize>,
+    ) -> HashMap<String, UTXOView> {
+        let len = usize::try_from(self.data().unavailable_utxos.len())
+            .unwrap_or_else(|_| env::panic_str("Too many unavailable_utxos"));
+        let skip_n = from_index.unwrap_or(0);
+        let take_n = limit.unwrap_or(len - skip_n);
+        self.data()
+            .unavailable_utxos
+            .iter()
+            .skip(skip_n)
+            .take(take_n)
+            .map(|(k, v)| (k.clone(), v.into()))
+            .collect()
+    }
+
+    pub fn list_unavailable_utxos(
+        &self,
+        utxo_storage_keys: Vec<String>,
+    ) -> HashMap<String, Option<UTXOView>> {
+        utxo_storage_keys
+            .into_iter()
+            .map(|key| {
+                (
+                    key.clone(),
+                    self.data().unavailable_utxos.get(&key).map(Into::into),
+                )
+            })
+            .collect()
+    }
+
+    pub fn get_btc_pending_infos_paged(
+        &self,
+        from_index: Option<usize>,
+        limit: Option<usize>,
+    ) -> HashMap<String, BTCPendingInfoView> {
+        let len = usize::try_from(self.data().btc_pending_infos.len())
+            .unwrap_or_else(|_| env::panic_str("Too many btc_pending_infos"));
+        let skip_n = from_index.unwrap_or(0);
+        let take_n = limit.unwrap_or(len - skip_n);
+        self.data()
+            .btc_pending_infos
+            .iter()
+            .skip(skip_n)
+            .take(take_n)
+            .map(|(k, v)| {
+                let info: crate::BTCPendingInfo = v.into();
+                (k.clone(), (&info).into())
+            })
+            .collect()
+    }
+
+    pub fn list_btc_pending_infos(
+        &self,
+        btc_pending_ids: Vec<String>,
+    ) -> HashMap<String, Option<BTCPendingInfoView>> {
+        btc_pending_ids
+            .into_iter()
+            .map(|key| {
+                (
+                    key.clone(),
+                    self.internal_view_btc_pending_info(&key)
+                        .as_ref()
+                        .map(Into::into),
+                )
+            })
+            .collect()
+    }
+
+    /// Same as [`Self::get_utxos_paged`] but serializes `tx_bytes` as a base64 string.
+    pub fn get_utxos_paged_v2(
+        &self,
+        from_index: Option<usize>,
+        limit: Option<usize>,
     ) -> HashMap<String, UTXO> {
         let len = usize::try_from(self.data().utxos.len())
             .unwrap_or_else(|_| env::panic_str("Too many utxos"));
@@ -163,14 +261,16 @@ impl Contract {
             .collect()
     }
 
-    pub fn list_utxos(&self, utxo_storage_keys: Vec<String>) -> HashMap<String, Option<UTXO>> {
+    /// Same as [`Self::list_utxos`] but serializes `tx_bytes` as a base64 string.
+    pub fn list_utxos_v2(&self, utxo_storage_keys: Vec<String>) -> HashMap<String, Option<UTXO>> {
         utxo_storage_keys
             .into_iter()
             .map(|key| (key.clone(), self.data().utxos.get(&key).map(Into::into)))
             .collect()
     }
 
-    pub fn get_unavailable_utxos_paged(
+    /// Same as [`Self::get_unavailable_utxos_paged`] but serializes `tx_bytes` as a base64 string.
+    pub fn get_unavailable_utxos_paged_v2(
         &self,
         from_index: Option<usize>,
         limit: Option<usize>,
@@ -188,7 +288,8 @@ impl Contract {
             .collect()
     }
 
-    pub fn list_unavailable_utxos(
+    /// Same as [`Self::list_unavailable_utxos`] but serializes `tx_bytes` as a base64 string.
+    pub fn list_unavailable_utxos_v2(
         &self,
         utxo_storage_keys: Vec<String>,
     ) -> HashMap<String, Option<UTXO>> {
@@ -203,7 +304,9 @@ impl Contract {
             .collect()
     }
 
-    pub fn get_btc_pending_infos_paged(
+    /// Same as [`Self::get_btc_pending_infos_paged`] but serializes `tx_bytes_with_sign`
+    /// (and nested `vutxos[*].tx_bytes`) as base64 strings.
+    pub fn get_btc_pending_infos_paged_v2(
         &self,
         from_index: Option<usize>,
         limit: Option<usize>,
@@ -221,7 +324,9 @@ impl Contract {
             .collect()
     }
 
-    pub fn list_btc_pending_infos(
+    /// Same as [`Self::list_btc_pending_infos`] but serializes `tx_bytes_with_sign`
+    /// (and nested `vutxos[*].tx_bytes`) as base64 strings.
+    pub fn list_btc_pending_infos_v2(
         &self,
         btc_pending_ids: Vec<String>,
     ) -> HashMap<String, Option<BTCPendingInfo>> {

--- a/contracts/satoshi-bridge/src/btc_light_client/deposit.rs
+++ b/contracts/satoshi-bridge/src/btc_light_client/deposit.rs
@@ -1,3 +1,4 @@
+use near_sdk::json_types::Base64VecU8;
 use near_sdk::serde_json::Value;
 
 use crate::{
@@ -116,7 +117,7 @@ impl Contract {
     pub(crate) fn internal_verify_deposit_entry(
         &mut self,
         deposit_msg: DepositMsg,
-        tx_bytes: Vec<u8>,
+        tx_bytes: Base64VecU8,
         vout: usize,
         tx_block_blockhash: String,
         tx_index: u64,
@@ -128,7 +129,7 @@ impl Contract {
             "safe_deposit not supported in verify_deposit"
         );
         let path = get_deposit_path(&deposit_msg);
-        let transaction = WrappedTransaction::decode(&tx_bytes, &self.internal_config().chain)
+        let transaction = WrappedTransaction::decode(&tx_bytes.0, &self.internal_config().chain)
             .expect("Deserialization tx_bytes failed");
         let deposit_amount = u128::from(transaction.output()[vout].value.to_sat());
         require!(deposit_amount > 0, "Invalid deposit_amount");
@@ -170,7 +171,7 @@ impl Contract {
     pub(crate) fn internal_safe_verify_deposit_entry(
         &mut self,
         deposit_msg: DepositMsg,
-        tx_bytes: Vec<u8>,
+        tx_bytes: Base64VecU8,
         vout: usize,
         tx_block_blockhash: String,
         tx_index: u64,
@@ -187,7 +188,7 @@ impl Contract {
             .safe_deposit
             .unwrap_or_else(|| env::panic_str("safe_deposit is required in safe_verify_deposit"));
 
-        let transaction = WrappedTransaction::decode(&tx_bytes, &self.internal_config().chain)
+        let transaction = WrappedTransaction::decode(&tx_bytes.0, &self.internal_config().chain)
             .expect("Deserialization tx_bytes failed");
         let deposit_amount = transaction.output()[vout].value.to_sat().into();
         require!(deposit_amount > 0, "Invalid deposit_amount");

--- a/contracts/satoshi-bridge/src/btc_pending_info.rs
+++ b/contracts/satoshi-bridge/src/btc_pending_info.rs
@@ -2,8 +2,9 @@ use std::borrow::{Borrow, BorrowMut};
 
 use crate::{
     env, nano_to_sec, near, network, psbt_wrapper::PsbtWrapper, require, u128_dec_format,
-    AccountId, Contract, SignatureResponse, WrappedTransaction, U128, VUTXO,
+    AccountId, Contract, SignatureResponse, VUTXOView, WrappedTransaction, U128, VUTXO,
 };
+use near_sdk::json_types::Base64VecU8;
 
 #[near(serializers = [borsh, json])]
 #[derive(Clone, PartialEq, Eq)]
@@ -120,10 +121,57 @@ pub struct BTCPendingInfo {
     pub psbt_hex: String,
     pub vutxos: Vec<VUTXO>,
     pub signatures: Vec<Option<SignatureResponse>>,
+    pub tx_bytes_with_sign: Option<Base64VecU8>,
+    pub create_time_sec: u32,
+    pub last_sign_time_sec: u32,
+    pub state: PendingInfoState,
+}
+
+/// View-only mirror of [`BTCPendingInfo`] that serializes byte fields as JSON byte
+/// arrays for backward compatibility with off-chain clients (relayer).
+#[near(serializers = [json])]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Debug))]
+pub struct BTCPendingInfoView {
+    pub account_id: AccountId,
+    pub btc_pending_id: String,
+    #[serde(with = "u128_dec_format")]
+    pub transfer_amount: u128,
+    #[serde(with = "u128_dec_format")]
+    pub actual_received_amount: u128,
+    #[serde(with = "u128_dec_format")]
+    pub withdraw_fee: u128,
+    #[serde(with = "u128_dec_format")]
+    pub gas_fee: u128,
+    #[serde(with = "u128_dec_format")]
+    pub burn_amount: u128,
+    pub psbt_hex: String,
+    pub vutxos: Vec<VUTXOView>,
+    pub signatures: Vec<Option<SignatureResponse>>,
     pub tx_bytes_with_sign: Option<Vec<u8>>,
     pub create_time_sec: u32,
     pub last_sign_time_sec: u32,
     pub state: PendingInfoState,
+}
+
+impl From<&BTCPendingInfo> for BTCPendingInfoView {
+    fn from(p: &BTCPendingInfo) -> Self {
+        BTCPendingInfoView {
+            account_id: p.account_id.clone(),
+            btc_pending_id: p.btc_pending_id.clone(),
+            transfer_amount: p.transfer_amount,
+            actual_received_amount: p.actual_received_amount,
+            withdraw_fee: p.withdraw_fee,
+            gas_fee: p.gas_fee,
+            burn_amount: p.burn_amount,
+            psbt_hex: p.psbt_hex.clone(),
+            vutxos: p.vutxos.iter().map(Into::into).collect(),
+            signatures: p.signatures.clone(),
+            tx_bytes_with_sign: p.tx_bytes_with_sign.as_ref().map(|b| b.0.clone()),
+            create_time_sec: p.create_time_sec,
+            last_sign_time_sec: p.last_sign_time_sec,
+            state: p.state.clone(),
+        }
+    }
 }
 
 impl BTCPendingInfo {
@@ -298,9 +346,11 @@ impl BTCPendingInfo {
 
     pub fn get_transaction(&self, chain: &network::Chain) -> WrappedTransaction {
         WrappedTransaction::decode(
-            self.tx_bytes_with_sign
+            &self
+                .tx_bytes_with_sign
                 .as_ref()
-                .expect("Missing tx_bytes_with_sign"),
+                .expect("Missing tx_bytes_with_sign")
+                .0,
             chain,
         )
         .expect("Deserialization tx_bytes failed")

--- a/contracts/satoshi-bridge/src/chain_signature.rs
+++ b/contracts/satoshi-bridge/src/chain_signature.rs
@@ -191,7 +191,8 @@ impl Contract {
                 }
                 .emit();
 
-                btc_pending_info.tx_bytes_with_sign = Some(tx_bytes_with_sign);
+                btc_pending_info.tx_bytes_with_sign =
+                    Some(near_sdk::json_types::Base64VecU8(tx_bytes_with_sign));
                 btc_pending_info.to_pending_verify_stage();
 
                 let is_original_tx = btc_pending_info.get_original_tx_id().is_none();

--- a/contracts/satoshi-bridge/src/nbtc/burn.rs
+++ b/contracts/satoshi-bridge/src/nbtc/burn.rs
@@ -77,7 +77,7 @@ impl Contract {
         };
         if is_success {
             let tx_bytes = btc_pending_info.tx_bytes_with_sign.as_ref().unwrap();
-            let transaction = WrappedTransaction::decode(tx_bytes, &self.internal_config().chain)
+            let transaction = WrappedTransaction::decode(&tx_bytes.0, &self.internal_config().chain)
                 .expect("Deserialization tx_bytes failed");
             let withdraw_change_script_pubkey = config.get_change_script_pubkey();
             let mut utxo_storage_keys = vec![];
@@ -159,7 +159,7 @@ impl Contract {
         };
         if is_success {
             let tx_bytes = btc_pending_info.tx_bytes_with_sign.as_ref().unwrap();
-            let transaction = WrappedTransaction::decode(tx_bytes, &self.internal_config().chain)
+            let transaction = WrappedTransaction::decode(&tx_bytes.0, &self.internal_config().chain)
                 .expect("Deserialization tx_bytes failed");
             let config = self.internal_config();
             let withdraw_change_script_pubkey = config.get_change_script_pubkey();

--- a/contracts/satoshi-bridge/src/refund.rs
+++ b/contracts/satoshi-bridge/src/refund.rs
@@ -200,7 +200,7 @@ impl Contract {
         let path = get_deposit_path(&deposit_msg);
         let vutxo = VUTXO::Current(UTXO {
             path,
-            tx_bytes: refund_request.tx_bytes.0.clone(),
+            tx_bytes: refund_request.tx_bytes.clone(),
             vout: refund_request.vout,
             balance: u64::try_from(refund_request.amount)
                 .unwrap_or_else(|_| env::panic_str("Amount overflow")),

--- a/contracts/satoshi-bridge/src/unit/storage.rs
+++ b/contracts/satoshi-bridge/src/unit/storage.rs
@@ -20,7 +20,7 @@ impl Contract {
             utxo_storage_key.clone(),
             VUTXO::Current(UTXO {
                 path,
-                tx_bytes,
+                tx_bytes: near_sdk::json_types::Base64VecU8(tx_bytes),
                 vout: vout.try_into().unwrap(),
                 balance: u64::MAX,
             }),

--- a/contracts/satoshi-bridge/src/utxo.rs
+++ b/contracts/satoshi-bridge/src/utxo.rs
@@ -2,16 +2,63 @@ use crate::{
     generate_utxo_storage_key, near, psbt_wrapper::PsbtWrapper, u64_dec_format, Contract, OutPoint,
 };
 use near_sdk::env;
+use near_sdk::json_types::Base64VecU8;
 
 #[near(serializers = [borsh, json])]
 #[derive(Clone)]
 #[cfg_attr(not(target_arch = "wasm32"), derive(Debug))]
 pub struct UTXO {
     pub path: String,
+    pub tx_bytes: Base64VecU8,
+    pub vout: usize,
+    #[serde(with = "u64_dec_format")]
+    pub balance: u64,
+}
+
+/// View-only mirror of [`UTXO`] that serializes `tx_bytes` as a JSON byte array
+/// for backward compatibility with off-chain clients (relayer).
+#[near(serializers = [json])]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Debug))]
+pub struct UTXOView {
+    pub path: String,
     pub tx_bytes: Vec<u8>,
     pub vout: usize,
     #[serde(with = "u64_dec_format")]
     pub balance: u64,
+}
+
+impl From<&UTXO> for UTXOView {
+    fn from(u: &UTXO) -> Self {
+        UTXOView {
+            path: u.path.clone(),
+            tx_bytes: u.tx_bytes.0.clone(),
+            vout: u.vout,
+            balance: u.balance,
+        }
+    }
+}
+
+/// View-only mirror of [`VUTXO`] preserving the legacy JSON shape (`{"Current": {...}}`).
+#[near(serializers = [json])]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Debug))]
+pub enum VUTXOView {
+    Current(UTXOView),
+}
+
+impl From<&VUTXO> for VUTXOView {
+    fn from(v: &VUTXO) -> Self {
+        match v {
+            VUTXO::Current(c) => VUTXOView::Current(c.into()),
+        }
+    }
+}
+
+impl From<&VUTXO> for UTXOView {
+    fn from(v: &VUTXO) -> Self {
+        match v {
+            VUTXO::Current(c) => c.into(),
+        }
+    }
 }
 
 #[near(serializers = [borsh, json])]


### PR DESCRIPTION
## Summary
- `UTXO.tx_bytes` and `BTCPendingInfo.tx_bytes_with_sign` switched from `Vec<u8>` to `Base64VecU8` internally — compact base64 in JSON instead of arrays of numbers, saving gas on cross-contract callback args.
- Legacy view methods preserve the old format via `UTXOView` / `BTCPendingInfoView` (return `tx_bytes` as a JSON byte array). Off-chain clients keep working without changes.
- Added `*_v2` view methods that return `UTXO` / `BTCPendingInfo` directly with base64 encoding.

## State migration
Not required. `Base64VecU8(pub Vec<u8>)` is borsh-identical to `Vec<u8>`.
