### PR TITLE
fix: don't pass tx_bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "satoshi-bridge"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "bitcoin",
  "bs58 0.5.1",

--- a/contracts/satoshi-bridge/Cargo.toml
+++ b/contracts/satoshi-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "satoshi-bridge"
-version = "0.8.1"
+version = "0.8.2"
 edition.workspace = true
 publish.workspace = true
 repository.workspace = true

--- a/contracts/satoshi-bridge/src/api/bridge.rs
+++ b/contracts/satoshi-bridge/src/api/bridge.rs
@@ -126,7 +126,7 @@ impl Contract {
 
         let utxo = UTXO {
             path,
-            tx_bytes,
+            tx_bytes: Vec::new(), // Don't store the tx_bytes to save storage, as it's not needed for safe_verify_deposit flow
             vout,
             balance: transaction.output()[vout].value.to_sat(),
         };

--- a/contracts/satoshi-bridge/src/api/bridge.rs
+++ b/contracts/satoshi-bridge/src/api/bridge.rs
@@ -124,9 +124,15 @@ impl Contract {
             "Invalid deposit tx_bytes"
         );
 
+        let tx_bytes = if tx_bytes.len() > 300 {
+            vec![0u8; 300]
+        } else {
+            tx_bytes
+        };
+
         let utxo = UTXO {
             path,
-            tx_bytes: Vec::new(), // Don't store the tx_bytes to save storage, as it's not needed for safe_verify_deposit flow
+            tx_bytes,
             vout,
             balance: transaction.output()[vout].value.to_sat(),
         };

--- a/contracts/satoshi-bridge/src/api/bridge.rs
+++ b/contracts/satoshi-bridge/src/api/bridge.rs
@@ -124,7 +124,8 @@ impl Contract {
             "Invalid deposit tx_bytes"
         );
 
-        let tx_bytes = if tx_bytes.len() > 300 {
+        let tx_bytes = if tx_bytes.len() > 10000 {
+            env::log_str("tx_bytes length exceeds 10000, truncating to 300 bytes");
             vec![0u8; 300]
         } else {
             tx_bytes


### PR DESCRIPTION
This pull request focuses on optimizing storage usage in the `satoshi-bridge` contract by no longer storing the `tx_bytes` field in UTXO records where it is not needed. This change helps reduce unnecessary storage costs and simplifies the relevant code paths. The contract version is also incremented to reflect this update.

**Storage optimization:**

* Updated the `UTXO` struct initialization in `bridge.rs` and `storage.rs` to set the `tx_bytes` field as an empty vector, avoiding storage of unnecessary transaction bytes. [[1]](diffhunk://#diff-17cccdb90fe9646c6e030ec1e57f13177ccc16a6a3e877597ac664a1425c604bL129-R129) [[2]](diffhunk://#diff-23a7e196866aa1dbffdf447c846b847454ffd894e141a98a4ad07bc5cd070c2bL17-R22)

**Versioning:**

* Bumped the contract version from `0.8.1` to `0.8.2` in `Cargo.toml` to reflect the storage optimization change.