### PR TITLE
feat(psbt): allow UnrestrictedRelayer to bypass change<min_input rule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "satoshi-bridge"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "bitcoin",
  "bs58 0.5.1",

--- a/contracts/satoshi-bridge/Cargo.toml
+++ b/contracts/satoshi-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "satoshi-bridge"
-version = "0.8.3"
+version = "0.8.4"
 edition.workspace = true
 publish.workspace = true
 repository.workspace = true

--- a/contracts/satoshi-bridge/src/psbt.rs
+++ b/contracts/satoshi-bridge/src/psbt.rs
@@ -1,6 +1,8 @@
+use near_plugins::AccessControllable;
+
 use crate::{
-    env, network::Address, psbt_wrapper::PsbtWrapper, require, Amount, Contract, Event, ScriptBuf,
-    TxOut, U128, VUTXO,
+    env, network::Address, psbt_wrapper::PsbtWrapper, require, Amount, Contract, Event, Role,
+    ScriptBuf, TxOut, U128, VUTXO,
 };
 
 impl Contract {
@@ -169,12 +171,15 @@ impl Contract {
         withdraw_fee: u128,
     ) -> (usize, usize, u128, u128) {
         let config = self.internal_config();
-        let input_amounts = vutxos.iter().map(|vutxo| u128::from(vutxo.get_amount()));
-        let min_input_amount = input_amounts.clone().min().unwrap();
-        let total_input_amount = input_amounts.sum::<u128>();
+        let (min_input_amount, total_input_amount) = vutxos
+            .iter()
+            .map(|vutxo| u128::from(vutxo.get_amount()))
+            .fold((u128::MAX, 0u128), |(min, sum), v| (min.min(v), sum + v));
         let mut total_output_amount = 0;
         let mut actual_received_amounts = vec![];
         let mut change_amounts = vec![];
+        let signer_is_unrestricted =
+            self.acl_has_role(Role::UnrestrictedRelayer.into(), env::signer_account_id());
 
         if !psbt.get_output().is_empty() {
             let target_address_script_pubkey = self
@@ -192,8 +197,8 @@ impl Contract {
                         "The change amount is too small"
                     );
                     require!(
-                        output_value < min_input_amount,
-                        "The change amount must be less than all inputs"
+                        signer_is_unrestricted || output_value < min_input_amount,
+                        "The change amount must be less than the smallest input, or the caller must have the UnrestrictedRelayer role"
                     );
                     change_amounts.push(output_value);
                 } else {

--- a/contracts/satoshi-bridge/tests/setup/context.rs
+++ b/contracts/satoshi-bridge/tests/setup/context.rs
@@ -518,6 +518,23 @@ impl Context {
             .await
     }
 
+    pub async fn bridge_acl_revoke_role(
+        &self,
+        caller: &str,
+        role: &str,
+        account_id: &AccountId,
+    ) -> Result<ExecutionFinalResult> {
+        self.get_account_by_name(caller)
+            .call(self.bridge_contract.id(), "acl_revoke_role")
+            .args_json(json!({
+                "role": role,
+                "account_id": account_id
+            }))
+            .max_gas()
+            .transact()
+            .await
+    }
+
     pub async fn bridge_add_super_admin(
         &self,
         caller: &str,

--- a/contracts/satoshi-bridge/tests/test_satoshi_bridge.rs
+++ b/contracts/satoshi-bridge/tests/test_satoshi_bridge.rs
@@ -1588,50 +1588,57 @@ async fn test_utxo_passive_management() {
     );
     check!(context.set_passive_management_limit(0, u32::MAX));
     let total_change = 500000 + 60000 - (withdraw_amount - withdraw_fee) as u64;
+    let make_withdraw_msg = || TokenReceiverMessage::Withdraw {
+        target_btc_address: TARGET_ADDRESS.to_string(),
+        input: vec![
+            OutPoint {
+                txid: utxo500000[0].parse().unwrap(),
+                vout: utxo500000[1].parse().unwrap(),
+            },
+            OutPoint {
+                txid: utxo60000[0].parse().unwrap(),
+                vout: utxo60000[1].parse().unwrap(),
+            },
+        ],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat((withdraw_amount - btc_gas_fee - withdraw_fee) as u64),
+                script_pubkey: Address::parse(TARGET_ADDRESS, get_chain())
+                    .expect("Invalid btc address")
+                    .script_pubkey()
+                    .expect("Failed to get script pubkey"),
+            },
+            TxOut {
+                value: Amount::from_sat(total_change),
+                script_pubkey: Address::parse(withdraw_change_address.as_str(), get_chain())
+                    .expect("Invalid btc address")
+                    .script_pubkey()
+                    .expect("Failed to get script pubkey"),
+            },
+        ],
+        max_gas_fee: None,
+        chain_specific_data: None,
+    };
+
+    // Without the UnrestrictedRelayer role the `change < smallest input` rule still fires
+    // (here change = 360_000 + change_fee_adjustment, smallest input = 60_000).
+    check!(context.bridge_acl_revoke_role(
+        "root",
+        "UnrestrictedRelayer",
+        &context.get_account_by_name("alice").sdk_id()
+    ));
     check!(
-        context.do_withdraw(
-            "alice",
-            "bridge",
-            withdraw_amount,
-            TokenReceiverMessage::Withdraw {
-                target_btc_address: TARGET_ADDRESS.to_string(),
-                input: vec![
-                    OutPoint {
-                        txid: utxo500000[0].parse().unwrap(),
-                        vout: utxo500000[1].parse().unwrap(),
-                    },
-                    OutPoint {
-                        txid: utxo60000[0].parse().unwrap(),
-                        vout: utxo60000[1].parse().unwrap(),
-                    }
-                ],
-                output: vec![
-                    TxOut {
-                        value: Amount::from_sat(
-                            (withdraw_amount - btc_gas_fee - withdraw_fee) as u64
-                        ),
-                        script_pubkey: Address::parse(TARGET_ADDRESS, get_chain())
-                            .expect("Invalid btc address")
-                            .script_pubkey()
-                            .expect("Failed to get script pubkey")
-                    },
-                    TxOut {
-                        value: Amount::from_sat(total_change),
-                        script_pubkey: Address::parse(
-                            withdraw_change_address.as_str(),
-                            get_chain()
-                        )
-                        .expect("Invalid btc address")
-                        .script_pubkey()
-                        .expect("Failed to get script pubkey")
-                    }
-                ],
-                max_gas_fee: None,
-                chain_specific_data: None,
-            }
-        ),
-        "The change amount must be less than all inputs"
+        context.do_withdraw("alice", "bridge", withdraw_amount, make_withdraw_msg()),
+        "The change amount must be less than the smallest input"
     );
+
+    // Granting UnrestrictedRelayer back bypasses the rule and the same PSBT succeeds.
+    check!(context.bridge_acl_grant_role(
+        "root",
+        "UnrestrictedRelayer",
+        &context.get_account_by_name("alice").sdk_id()
+    ));
+    check!(context.do_withdraw("alice", "bridge", withdraw_amount, make_withdraw_msg()));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
Lets accounts with the `UnrestrictedRelayer` role submit withdraw PSBTs where a change output is `>= min(inputs)`. The standard `change < smallest_input` rule still applies to everyone else.

## Motivation
The off-chain consolidation/anchor-fill selector in [bridge-sdk-rs#281](https://github.com/Near-One/bridge-sdk-rs/pull/281) intentionally produces withdraws that consume many small UTXOs (fillers) with a single large anchor input, emitting one sizable change output. That's the shape the contract rule blocks: with `min_input = filler_size`, the rule would force the change into 100+ sub-`min_change_amount` pieces — no valid split exists, so consolidation withdraws are unbuildable today.

The relaxation only affects a UTXO-management invariant. All value-flow checks remain enforced for every caller:
- `min_change_amount` and `max_change_amount`
- `change_amounts.all(|v| v < max_change_amount) when input_num > change_num` (still caps any single change piece)
- `min_btc_gas_fee` / `max_btc_gas_fee`
- `actual_received_amount` window (`max - min_change_amount` .. `max`)

A misbehaving role holder can fragment / waste UTXOs (each input requires a Chain Signatures MPC sign), not steal funds. This matches the trust model the role already implies — `UnrestrictedRelayer` already gates the bridge's `#[trusted_relayer]` methods.

## Changes

**`contracts/satoshi-bridge/src/psbt.rs`**
- Add `signer_is_unrestricted = acl_has_role(UnrestrictedRelayer, signer)` check, hoisted out of the per-output loop (one ACL read per call instead of one per change output).
- Bypass `change < min_input_amount` when the signer has `UnrestrictedRelayer`.
- Update error message to reflect both branches.
- Replace the cloned iterator + two passes for `min` and `sum` with a single `fold` over `vutxos`.

**`contracts/satoshi-bridge/tests/setup/context.rs`**
- Add `bridge_acl_revoke_role` helper (mirrors `bridge_acl_grant_role`).

**`contracts/satoshi-bridge/tests/test_satoshi_bridge.rs`**
- Extend `test_utxo_passive_management` to revoke `alice`'s role, assert the rule still fires with the new message, then re-grant the role and assert the same PSBT succeeds.

## Why `signer_account_id()`
In both code paths that reach `check_withdraw_psbt`:
- `ft_on_transfer` → `check_withdraw_psbt`: signer is the end user (NEAR forwards the original tx signer across the nBTC → bridge promise chain). `predecessor` is the nBTC contract, so it would be wrong here.
- `withdraw_rbf` → `check_withdraw_psbt`: signer is the caller, which is already `UnrestrictedRelayer`-gated via `#[trusted_relayer]`.

## Behavior note
The `min`/`sum` refactor changes the empty-`vutxos` case from `panic` (via `.min().unwrap()`) to `(u128::MAX, 0)`. The empty case isn't reachable in practice and is still caught downstream by the `actual_received_amounts.len() == 1` check, `gas_fee >= min_btc_gas_fee`, and `overflow-checks = true` on the `total_input - total_output` subtraction.

## Test plan
- [x] `cargo test --features bitcoin -p satoshi-bridge --test test_satoshi_bridge` — 15/15 passing, including `test_utxo_passive_management` exercising both branches.
- [x] `make clippy-bitcoin` clean.
- [ ] Verify the anchor-fill SDK can now submit consolidation withdraws end-to-end against this contract.
