### PR TITLE
fix(zcash): support shielded-only addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "satoshi-bridge"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "bitcoin",
  "bs58 0.5.1",

--- a/contracts/satoshi-bridge/Cargo.toml
+++ b/contracts/satoshi-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "satoshi-bridge"
-version = "0.8.4"
+version = "0.8.5"
 edition.workspace = true
 publish.workspace = true
 repository.workspace = true

--- a/contracts/satoshi-bridge/src/config.rs
+++ b/contracts/satoshi-bridge/src/config.rs
@@ -174,6 +174,21 @@ impl Config {
             .expect("Failed to get script pubkey")
     }
 
+    /// scriptPubKey for a withdrawal target address, or `None` when the address has no
+    /// transparent receiver (e.g. a shielded-only Zcash unified address that carries only
+    /// Sapling/Orchard receivers). Such a recipient is paid via the Orchard bundle, so the
+    /// withdrawal's transparent outputs are all change and there is no target scriptPubKey
+    /// to match against. The address must still be parseable for the configured chain; an
+    /// unparseable address panics, matching `string_to_script_pubkey`.
+    pub fn target_script_pubkey(&self, address_string: &str) -> Option<ScriptBuf> {
+        let chain = self.get_utxo_network();
+
+        Address::parse(address_string, chain)
+            .unwrap_or_else(|e| env::panic_str(&format!("{address_string}: {e}")))
+            .script_pubkey()
+            .ok()
+    }
+
     pub fn get_utxo_network(&self) -> network::Chain {
         self.chain.clone()
     }
@@ -358,5 +373,47 @@ mod tests {
 
         assert_eq!(config_after.min_deposit_amount, 21000);
         assert_eq!(config_after.min_change_amount, 500);
+    }
+
+    // Regression: a Zcash unified address with no transparent receiver (shielded-only,
+    // e.g. Sapling+Orchard) has no scriptPubKey. `string_to_script_pubkey` panics on it
+    // ("Failed to get script pubkey: No receiver found in address"), which is what broke
+    // Orchard withdrawals to such addresses. `target_script_pubkey` must return `None`
+    // for it (so the withdraw path treats transparent outputs as change) while still
+    // resolving transparent addresses.
+    #[test]
+    #[cfg(feature = "zcash")]
+    fn test_target_script_pubkey_shielded_only_ua_is_none() {
+        use crate::network::{Address, Chain};
+
+        let mut unit_env = init_unit_env();
+        let config = unit_env.contract.internal_mut_config();
+        config.chain = Chain::ZcashMainnet;
+
+        // Real mainnet recipient from the failed withdrawal: Sapling + Orchard, no
+        // transparent receiver.
+        let shielded_only_ua = "u15a97e324mckwx89t0ucxytpd7v3pfzey7daldrk4mwu3u55ej39f6v7myqjxw0e098hnhyp0tvfgfnxj8swt22rl4f77a8wrg9zjynh9dwj20lf232h7yzfr0v53l2s824l22l63xwlxyypnxkx9qq7dd249pj565q7490fey5czu2pm";
+
+        // Precondition documenting the bug: the address parses, but yields no scriptPubKey.
+        assert!(
+            Address::parse(shielded_only_ua, Chain::ZcashMainnet)
+                .expect("valid unified address")
+                .script_pubkey()
+                .is_err(),
+            "fixture must be a shielded-only UA with no transparent receiver"
+        );
+
+        assert!(
+            config.target_script_pubkey(shielded_only_ua).is_none(),
+            "shielded-only UA must yield no transparent scriptPubKey instead of panicking"
+        );
+
+        // A transparent t1 address still resolves to a scriptPubKey.
+        assert!(
+            config
+                .target_script_pubkey("t1KfwsnwJeNRVjQGBDZhwKskpQbih2qx5Ua")
+                .is_some(),
+            "transparent address must resolve to a scriptPubKey"
+        );
     }
 }

--- a/contracts/satoshi-bridge/src/psbt.rs
+++ b/contracts/satoshi-bridge/src/psbt.rs
@@ -182,14 +182,17 @@ impl Contract {
             self.acl_has_role(Role::UnrestrictedRelayer.into(), env::signer_account_id());
 
         if !psbt.get_output().is_empty() {
+            // `None` when the target is a shielded-only Zcash unified address (no transparent
+            // receiver): the user is paid via the Orchard bundle and every transparent output
+            // is change, so there is nothing for a transparent output to match against.
             let target_address_script_pubkey = self
                 .internal_config()
-                .string_to_script_pubkey(&target_btc_address);
+                .target_script_pubkey(&target_btc_address);
 
             psbt.get_output().iter().for_each(|output| {
                 let output_value = output.value.to_sat() as u128;
                 total_output_amount += output_value;
-                if output.script_pubkey == target_address_script_pubkey {
+                if target_address_script_pubkey.as_ref() == Some(&output.script_pubkey) {
                     actual_received_amounts.push(output_value);
                 } else if &output.script_pubkey == withdraw_change_address_script_pubkey {
                     require!(

--- a/contracts/satoshi-bridge/tests/setup/orchard.rs
+++ b/contracts/satoshi-bridge/tests/setup/orchard.rs
@@ -90,6 +90,29 @@ pub fn gen_ua_and_orchard_bundle_hex(amount: u64, network: &str) -> (String, Str
     gen_ua_and_orchard_bundle_hex_with_key(amount, network, None)
 }
 
+/// Produce a Unified Address containing ONLY an Orchard receiver (no transparent receiver),
+/// derived from `spending_key_bytes` (default `[7u8; 32]`). This reproduces a shielded-only
+/// recipient like the ones privacy wallets emit. It is cheap (derives the address only, no
+/// Halo2 proof), and the Orchard receiver matches the bundle produced by
+/// `gen_ua_and_orchard_bundle_hex*` for the same key, so a cached bundle can be reused as the
+/// payment.
+pub fn orchard_only_ua_with_key(network: &str, spending_key_bytes: Option<[u8; 32]>) -> String {
+    let sk_bytes = spending_key_bytes.unwrap_or([7u8; 32]);
+    let sk = SpendingKey::from_bytes(sk_bytes).expect("spending key");
+    let fvk = FullViewingKey::from(&sk);
+    let recipient = fvk.address_at(0u32, Scope::External);
+    let orchard_raw = recipient.to_raw_address_bytes();
+
+    let ua = zcash_address::unified::Address::try_from_items(vec![Receiver::Orchard(orchard_raw)])
+        .expect("UA from orchard receiver");
+
+    let network_type = match network {
+        "main" | "mainnet" => zcash_protocol::consensus::NetworkType::Main,
+        _ => zcash_protocol::consensus::NetworkType::Test,
+    };
+    ZcashAddress::from_unified(network_type, ua).encode()
+}
+
 /// Get or generate a cached Orchard bundle for the given amount.
 /// Caches to a local file to avoid expensive regeneration.
 pub fn get_or_gen_bundle(amount: u64) -> (String, String) {

--- a/contracts/satoshi-bridge/tests/test_orchard_withdrawal.rs
+++ b/contracts/satoshi-bridge/tests/test_orchard_withdrawal.rs
@@ -145,6 +145,128 @@ async fn test_orchard_withdrawal_with_ovk_validation() {
     println!("✅ Withdrawal with Orchard bundle completed successfully");
 }
 
+/// Regression: an Orchard withdrawal whose recipient is a *shielded-only* unified address
+/// (Orchard receiver, NO transparent receiver) must succeed. Previously `check_withdraw_psbt`
+/// eagerly derived the recipient's transparent scriptPubKey to classify the transparent change
+/// output, panicking with "Failed to get script pubkey: No receiver found in address" for a UA
+/// that has no transparent receiver. The other Orchard tests masked this because their fixture
+/// UA also carries a transparent (P2PKH) receiver.
+#[tokio::test]
+#[cfg(feature = "zcash")]
+async fn test_orchard_withdrawal_to_shielded_only_ua() {
+    std::env::set_var("TEST_CHAIN", "ZcashTestnet");
+
+    let worker = near_workspaces::sandbox().await.unwrap();
+    let context = Context::new(&worker, None).await;
+
+    check!(context.set_deposit_bridge_fee(10000, 0, 9000));
+    check!(context.set_withdraw_bridge_fee(20000, 0, 9000));
+
+    let config = context.get_bridge_config().await.unwrap();
+    assert_eq!(format!("{:?}", config.chain), "ZcashTestnet");
+
+    // Deposit for alice.
+    let alice_btc_deposit_address = context
+        .get_user_deposit_address(DepositMsg {
+            recipient_id: context.get_account_by_name("alice").sdk_id(),
+            post_actions: None,
+            extra_msg: None,
+            safe_deposit: None,
+            refund_address: None,
+        })
+        .await
+        .unwrap();
+
+    let zcash_tx_bytes = setup::utils::generate_transaction_bytes(
+        vec![(
+            "c6774e76452c36bba6c357653f620a4364fc063ba021e2acf6049f8d9e6b0234",
+            1,
+            None,
+        )],
+        vec![
+            ("1MgiBKohM2poApYamQadp21vJrNyh5T19G", 90000),
+            (alice_btc_deposit_address.as_str(), 500000),
+        ],
+    );
+
+    check!(context.verify_deposit(
+        "relayer",
+        DepositMsg {
+            recipient_id: context.get_account_by_name("alice").sdk_id(),
+            post_actions: None,
+            extra_msg: None,
+            safe_deposit: None,
+            refund_address: None,
+        },
+        zcash_tx_bytes,
+        1,
+        "0000000000000c3f818b0b6374c609dd8e548a0a9e61065e942cd466c426e00d".to_string(),
+        1,
+        vec![]
+    ));
+
+    let utxos_keys = context
+        .get_utxos_paged()
+        .await
+        .unwrap()
+        .keys()
+        .cloned()
+        .collect::<Vec<String>>();
+    assert!(!utxos_keys.is_empty(), "Should have UTXOs after deposit");
+    let first_utxo = utxos_keys[0].split('@').collect::<Vec<_>>();
+
+    let utxo_value = 500000u128;
+    let withdraw_amount = 200000u128;
+    let btc_gas_fee = 10000u128;
+    let withdraw_fee = config.withdraw_bridge_fee.get_fee(withdraw_amount);
+    let orchard_amount = (withdraw_amount - withdraw_fee - btc_gas_fee) as u64;
+    let change_amount = utxo_value - orchard_amount as u128 - btc_gas_fee;
+
+    // Reuse the cached bundle for this amount; we only need its bundle bytes. The Orchard
+    // receiver is derived from the same default key, so the shielded-only UA below is the
+    // bundle's recipient.
+    let (_ua_with_transparent, bundle_hex) = setup::orchard::get_or_gen_bundle(orchard_amount);
+    let recipient_ua = setup::orchard::orchard_only_ua_with_key("testnet", None);
+
+    // The recipient must be a shielded-only UA: no transparent receiver, hence no scriptPubKey.
+    assert!(
+        Address::parse(&recipient_ua, Chain::ZcashTestnet)
+            .expect("valid unified address")
+            .script_pubkey()
+            .is_err(),
+        "fixture must be a shielded-only UA (no transparent receiver)"
+    );
+
+    let withdraw_change_address = context.get_change_address().await.unwrap();
+    let change_script_pubkey = Address::parse(&withdraw_change_address, Chain::ZcashTestnet)
+        .expect("Invalid change address")
+        .script_pubkey()
+        .expect("Failed to get script pubkey");
+
+    // Orchard withdrawal with a transparent change output back to the bridge.
+    check!(context.do_withdraw(
+        "alice",
+        "bridge",
+        withdraw_amount,
+        TokenReceiverMessage::Withdraw {
+            target_btc_address: recipient_ua.clone(),
+            input: vec![OutPoint {
+                txid: first_utxo[0].parse().unwrap(),
+                vout: first_utxo[1].parse().unwrap(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(change_amount as u64),
+                script_pubkey: change_script_pubkey,
+            }],
+            max_gas_fee: None,
+            chain_specific_data: Some(ChainSpecificData {
+                orchard_bundle_bytes: hex::decode(&bundle_hex).unwrap().into(),
+                expiry_height: 10000,
+            }),
+        }
+    ));
+}
+
 #[tokio::test]
 #[cfg(feature = "zcash")]
 async fn test_orchard_withdrawal_amount_mismatch() {


### PR DESCRIPTION
This pull request addresses a regression in the handling of Zcash unified addresses (UAs) that do not have a transparent receiver (i.e., shielded-only UAs such as Sapling+Orchard). Previously, withdrawals to these addresses would panic because the code attempted to derive a transparent scriptPubKey, which does not exist for shielded-only UAs. The changes ensure that such addresses are correctly handled by returning `None` for their transparent scriptPubKey, allowing withdrawals to shielded-only recipients to succeed. The update also adds tests to prevent regressions and utilities for generating shielded-only UAs in tests.

**Fixes and improvements for shielded-only Zcash unified addresses:**

* Added a new method `target_script_pubkey` to `Config` that returns `None` for shielded-only UAs, preventing panics and allowing proper classification of transparent outputs as change.
* Updated withdrawal logic in `psbt.rs` to use `target_script_pubkey`, ensuring shielded-only recipients are handled without error.

**Testing and regression coverage:**

* Added a regression test to verify that `target_script_pubkey` returns `None` for shielded-only UAs and still resolves transparent addresses correctly.
* Added a regression integration test to ensure Orchard withdrawals to shielded-only UAs succeed, covering the previously failing scenario.

**Test utilities:**

* Introduced a utility function `orchard_only_ua_with_key` to generate shielded-only unified addresses for use in tests.