### PR TITLE
fix: increase limits for confirmations strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3768,7 +3768,7 @@ dependencies = [
 
 [[package]]
 name = "satoshi-bridge"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "bitcoin",
  "bs58 0.5.1",

--- a/contracts/satoshi-bridge/Cargo.toml
+++ b/contracts/satoshi-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "satoshi-bridge"
-version = "0.9.2"
+version = "0.9.3"
 edition.workspace = true
 publish.workspace = true
 repository.workspace = true

--- a/contracts/satoshi-bridge/src/api/management.rs
+++ b/contracts/satoshi-bridge/src/api/management.rs
@@ -282,7 +282,7 @@ impl Contract {
     pub fn set_confirmations_strategy(&mut self, range_upper_bound: U128, confirmations: u8) {
         assert_one_yocto();
 
-        let mut config = self.internal_mut_config();
+        let config = self.internal_mut_config();
         config
             .confirmations_strategy
             .insert(range_upper_bound.0.to_string(), confirmations);

--- a/contracts/satoshi-bridge/src/api/management.rs
+++ b/contracts/satoshi-bridge/src/api/management.rs
@@ -282,8 +282,8 @@ impl Contract {
     pub fn set_confirmations_strategy(&mut self, range_upper_bound: U128, confirmations: u8) {
         assert_one_yocto();
         require!(
-            (2..=10).contains(&confirmations),
-            "The number of confirmations must be between 2 and 10, including both 2 and 10."
+            (2..=1000).contains(&confirmations),
+            "The number of confirmations must be between 2 and 1000, including both 2 and 1000."
         );
         self.internal_mut_config()
             .confirmations_strategy

--- a/contracts/satoshi-bridge/src/api/management.rs
+++ b/contracts/satoshi-bridge/src/api/management.rs
@@ -281,13 +281,13 @@ impl Contract {
     #[access_control_any(roles(Role::DAO))]
     pub fn set_confirmations_strategy(&mut self, range_upper_bound: U128, confirmations: u8) {
         assert_one_yocto();
-        require!(
-            (2..=1000).contains(&confirmations),
-            "The number of confirmations must be between 2 and 1000, including both 2 and 1000."
-        );
-        self.internal_mut_config()
+
+        let mut config = self.internal_mut_config();
+        config
             .confirmations_strategy
             .insert(range_upper_bound.0.to_string(), confirmations);
+
+        config.assert_valid()
     }
 
     #[payable]

--- a/contracts/satoshi-bridge/src/config.rs
+++ b/contracts/satoshi-bridge/src/config.rs
@@ -122,7 +122,7 @@ pub struct Config {
 
 impl Config {
     pub fn assert_valid(&self) {
-        let confirmations_valid_range = 2..=1000;
+        let confirmations_valid_range = 2..=100;
         require!(
             self.confirmations_strategy
                 .values()
@@ -373,6 +373,48 @@ mod tests {
 
         assert_eq!(config_after.min_deposit_amount, 21000);
         assert_eq!(config_after.min_change_amount, 500);
+    }
+
+    #[test]
+    fn test_set_confirmations_strategy_updates_config() {
+        let mut unit_env = init_unit_env();
+        testing_env!(unit_env
+            .context
+            .predecessor_account_id(owner_id())
+            .attached_deposit(NearToken::from_yoctonear(1))
+            .build());
+
+        let range_upper_bound = U128(20_000_000);
+        let confirmations = 6u8;
+
+        unit_env
+            .contract
+            .set_confirmations_strategy(range_upper_bound, confirmations);
+
+        assert_eq!(
+            unit_env
+                .contract
+                .internal_config()
+                .confirmations_strategy
+                .get(&range_upper_bound.0.to_string()),
+            Some(&confirmations),
+            "confirmations_strategy must be updated with the new entry"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid confirmations_strategy")]
+    fn test_set_confirmations_strategy_over_100_panics() {
+        let mut unit_env = init_unit_env();
+        testing_env!(unit_env
+            .context
+            .predecessor_account_id(owner_id())
+            .attached_deposit(NearToken::from_yoctonear(1))
+            .build());
+
+        unit_env
+            .contract
+            .set_confirmations_strategy(U128(20_000_000), 101);
     }
 
     // Regression: a Zcash unified address with no transparent receiver (shielded-only,

--- a/contracts/satoshi-bridge/src/config.rs
+++ b/contracts/satoshi-bridge/src/config.rs
@@ -122,7 +122,7 @@ pub struct Config {
 
 impl Config {
     pub fn assert_valid(&self) {
-        let confirmations_valid_range = 2..=100;
+        let confirmations_valid_range = 2..=1000;
         require!(
             self.confirmations_strategy
                 .values()


### PR DESCRIPTION
For ZCash, 10 confirmations is a very small limit. I increased the limit to 100. 